### PR TITLE
Add turbo as ITC preset mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,9 +23,10 @@ This custom component creates:
 * one fan entity for each group defined, which controls the zone damper
 * one climate entity for each group with ITC installed, which controls the zone temperature
 
-For each group with ITC, the fan entity can switch between 2 profiles:
+For each group with ITC, the fan entity can switch between 2 profiles (and Turbo if setup):
 * Damper - which allows direct damper control via the fan
 * ITC - which allows for temperature control using the ITC
+* Turbo - turbo for the group
 
 
 Enjoy!

--- a/custom_components/polyaire/airtouch4.py
+++ b/custom_components/polyaire/airtouch4.py
@@ -218,8 +218,8 @@ class AirTouch4():
         msg = Message.GROUP_CONTROL_REQUEST(group_number=group, target_type=GROUP_TARGET_TYPES.TEMPERATURE, target=int(temp))
         self._queue.put_nowait(msg)
 
-    async def request_group_control_type(self, group: int, control_type: int) -> None:
-        msg = Message.GROUP_CONTROL_REQUEST(group_number=group, control_type=control_type)
+    async def request_group_control_type(self, group: int, control_type: int = GROUP_CONTROL_TYPES.KEEP, power: int = None) -> None:
+        msg = Message.GROUP_CONTROL_REQUEST(group_number=group, control_type=control_type, power=power)
         self._queue.put_nowait(msg)
 
     async def request_group_power(self, group, power: int) -> None:

--- a/custom_components/polyaire/protocol.py
+++ b/custom_components/polyaire/protocol.py
@@ -39,6 +39,7 @@ AC_TARGET_KEEP = 63
 class PRESETS(SimpleNamespace):
     DAMPER = "Damper"
     ITC = "ITC"
+    TURBO = "Turbo"
 
 class GROUP_POWER_STATES(SimpleNamespace):
     KEEP = 0
@@ -259,6 +260,8 @@ class Message:
             power_state = GROUP_POWER_STATES.KEEP
         elif power == 0:
             power_state = GROUP_POWER_STATES.OFF
+        elif power == 3:
+            power_state = GROUP_POWER_STATES.TURBO
         else:
             power_state = GROUP_POWER_STATES.ON
 


### PR DESCRIPTION
If a group is set as the turbo group, allow an additional Turbo option for that ITC's presets. 